### PR TITLE
Adding Missing Opcodes to the Z80 Map

### DIFF
--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -75,12 +75,24 @@ class Z80 {
         0x2E: Instructions.LD_RB_NB,
         0x36: Instructions.LD_RB_NB,
         0x3E: Instructions.LD_RB_NB,
+        0x70: Instructions.LD_HL_RB,
+        0x71: Instructions.LD_HL_RB,
+        0x72: Instructions.LD_HL_RB,
+        0x73: Instructions.LD_HL_RB,
+        0x74: Instructions.LD_HL_RB,
+        0x75: Instructions.LD_HL_RB,
+        0x77: Instructions.LD_HL_RB,
+
         0xCB: this._execute16BitInstruction
     };
 
     private _16BitInstructions = new Array(256);
 
     constructor() {
+        const ldRbRbMap = Instructions.setLoadRegToRegVal(() => Instructions.LD_RB_RB);
+        
+        this._map = { ...this._map, ...ldRbRbMap };
+
         for (let i = 0x40; i <= 0x7f; i++) {
             this. _16BitInstructions[i] = Instructions.BITu3r8;
         }

--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -56,6 +56,8 @@ class Z80 {
     public _map = {
         0x83: Instructions.ADDr_e,
         0xB8: Instructions.CPr_b,
+        0xFE: Instructions.CP_A_NB,
+        0xCD: Instructions.CALL_NW,
         0xF3: Instructions.DI,
         0xFB: Instructions.EI,
         0x00: Instructions.NOP,
@@ -65,6 +67,16 @@ class Z80 {
         0x31: Instructions.LDSPnn,
         0xFA: Instructions.LD_A_NW,
         0xAF: Instructions.XORA,
+        0x03: Instructions.INC_NW,
+        0x13: Instructions.INC_NW,
+        0x23: Instructions.INC_NW,
+        0x04: Instructions.INC_RB, 
+        0x0C: Instructions.INC_RB,
+        0x14: Instructions.INC_RB,
+        0x1C: Instructions.INC_RB,
+        0x24: Instructions.INC_RB,
+        0x2C: Instructions.INC_RB,
+        0x3C: Instructions.INC_RB,
         0x01: Instructions.LD_RW_NW,
         0x11: Instructions.LD_RW_NW,
         0x21: Instructions.LD_RW_NW,
@@ -82,7 +94,13 @@ class Z80 {
         0x74: Instructions.LD_HL_RB,
         0x75: Instructions.LD_HL_RB,
         0x77: Instructions.LD_HL_RB,
-
+        0x32: Instructions.LD_HLD_A,
+        0xE2: Instructions.LDH_C_A,
+        0xE0: Instructions.LDH_NW_A,
+        0x20: Instructions.JR_cc_e8, 
+        0x28: Instructions.JR_cc_e8,
+        0x30: Instructions.JR_cc_e8,
+        0x38: Instructions.JR_cc_e8,
         0xCB: this._execute16BitInstruction
     };
 

--- a/src/instructions/16BitArithmetic.ts
+++ b/src/instructions/16BitArithmetic.ts
@@ -5,7 +5,7 @@ export const INC_NW = {
     m: 2,
     t: 8,
     action: ({ _r, opcode1 }) => {
-        const [upper, lower] = this.map[opcode1.AND(0xF).getVal()];
+        const [upper, lower] = this.map[opcode1.getVal() >> 4];
         const address: Address = new Address(_r[upper], _r[lower]);
         const newAddress: Address = address.ADD(1);
 

--- a/src/instructions/Load.ts
+++ b/src/instructions/Load.ts
@@ -118,6 +118,22 @@ const upper = {
 
 const lower = ['b', 'c', 'd', 'e', 'h', 'l', null, 'a'];
 
+export function setLoadRegToRegVal(setFunc): Object {
+    const map = {};
+    Object.keys(upper).forEach((upperStr) => {
+        upper[upperStr].forEach((upperVal, upperIndex) => {
+            if(upperVal){
+                lower.forEach((lowerVal, lowerIndex) => {
+                    if(lowerVal) {
+                        const lowerHalf = upperIndex ? lowerIndex + 8 : lowerIndex;
+                        this._map[Number(upperStr) << 4 + lowerHalf] = setFunc(upperVal, lowerVal); 
+                    }
+                });
+            }
+        });
+    });
+    return map;
+}
 
 export const LD_RB_RB = {
     m: 1,
@@ -127,17 +143,6 @@ export const LD_RB_RB = {
 
         _r[to] = _r[from];
     },
-    map: Object.keys(upper).reduce((acc, val) => {
-        upper[val].array.forEach((regTo: string, upperIndex: number) => {
-            lower.forEach((regFrom, lowerIndex) => {
-                const lowerHalf = upperIndex ? lowerIndex + 8 : lowerIndex;
-                if (val && regFrom) {
-                    acc[Number(val) << 4 + lowerHalf] = [regTo, regFrom]
-                }
-            });
-        });
-
-        return acc;
-    }, {}),
+    map: setLoadRegToRegVal((regTo, regFrom) => [regTo, regFrom]),
     bytes: 1
 } as InstructionMetaData;

--- a/src/instructions/index.ts
+++ b/src/instructions/index.ts
@@ -5,3 +5,4 @@ export * from 'Miscellaneous.js';
 export * from 'StackOperations.js';
 export * from 'BitOperations.js';
 export * from 'InstructionMetaData.js'
+export * from '16BitArithmetic.js';


### PR DESCRIPTION
A bunch of the instructions have not been added to the Z80 opcode map. This PR is adding a bunch in that I have missed. I have also consolidated some of the logic around building the LD r8,r8 so matrix function will work for both the map on the instruction metadata as well as the opcode map.