### PR TITLE
Add LD (n16), A | JR e8 | Sub r8 Instructions

### DIFF
--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -112,6 +112,7 @@ class Z80 {
         0x28: Instructions.JR_cc_e8,
         0x30: Instructions.JR_cc_e8,
         0x38: Instructions.JR_cc_e8,
+        0x18: Instructions.JR_EB,
         0xCB: this._execute16BitInstruction
     };
 

--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -86,6 +86,7 @@ class Z80 {
         0x3C: Instructions.INC_RB,
         0x0A: Instructions.LD_A_RW,
         0x1A: Instructions.LD_A_RW,
+        0xEA: Instructions.LD_NW_A,
         0x01: Instructions.LD_RW_NW,
         0x11: Instructions.LD_RW_NW,
         0x21: Instructions.LD_RW_NW,

--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -113,6 +113,13 @@ class Z80 {
         0x30: Instructions.JR_cc_e8,
         0x38: Instructions.JR_cc_e8,
         0x18: Instructions.JR_EB,
+        0x90: Instructions.SUB_A_RB,
+        0x91: Instructions.SUB_A_RB,
+        0x92: Instructions.SUB_A_RB,
+        0x93: Instructions.SUB_A_RB,
+        0x94: Instructions.SUB_A_RB,
+        0x95: Instructions.SUB_A_RB,
+        0x97: Instructions.SUB_A_RB,
         0xCB: this._execute16BitInstruction
     };
 

--- a/src/instructions/8BitArithmetic.ts
+++ b/src/instructions/8BitArithmetic.ts
@@ -133,3 +133,26 @@ export const DEC_RB = {
     },
     bytes: 1
 } as InstructionMetaData;
+
+export const SUB_A_RB = {
+    m: 1,
+    t: 4,
+    action: function({ _r, opcode1 }) {
+        const reg: string = this.map[opcode1.getVal() & 0xF];
+        const result = _r.a.ADD(-_r[reg].getVal());
+
+        _r.setN(1);
+
+        if (!result.AND(255).getVal()) {
+            _r.setZ(1);
+        }
+        if (result.getLastNibble().getVal() > 15) {
+            _r.setH(1)
+        }
+        if (_r[reg].getVal() > _r.a.getVal()) {
+            _r.setC(1);
+        }
+    },
+    map: ['b', 'c', 'd', 'e', 'h', 'l', null, 'a'],
+    bytes: 1
+} as InstructionMetaData;

--- a/src/instructions/JumpsAndSubroutines.ts
+++ b/src/instructions/JumpsAndSubroutines.ts
@@ -68,3 +68,13 @@ export const CALL_NW = {
     },
     bytes: 3
 } as InstructionMetaData;
+
+export const JR_EB = {
+    m:3,
+    t: 12,
+    action: function ({ _r, operand1 }): void {
+        _r.pc = _r.pc.ADD(this.bytes).ADD(operand1.getVal());
+        this.bytes = 0;
+    },
+    bytes: 2
+} as InstructionMetaData;

--- a/src/instructions/Load.ts
+++ b/src/instructions/Load.ts
@@ -169,8 +169,19 @@ export const LD_HLP_A = {
         const newAddr = address.ADD(1);
         MMU.wb(address, _r.a);
 
-        _r.h = address.getFirstByte();
-        _r.l = address.getLastByte();
+        _r.h = newAddr.getFirstByte();
+        _r.l = newAddr.getLastByte();
     },
     bytes: 1   
+} as InstructionMetaData;
+
+export const LD_NW_A = {
+    m: 4,
+    t: 16,
+    action: ({ _r, opcode1, opcode2 }) => {
+        const addr: Address = new Address(opcode1, opcode2);
+
+        MMU.wb(addr, _r.a);
+    },
+    bytes: 3
 } as InstructionMetaData;


### PR DESCRIPTION
Adding LD (n16), A | JR e8 | Sub r8 instructions logic to the application and their opcodes to the Z80 opcode map.

Closes #12 