### PR TITLE
Fix call infinite loop

### DIFF
--- a/src/instructions/JumpsAndSubroutines.ts
+++ b/src/instructions/JumpsAndSubroutines.ts
@@ -57,14 +57,13 @@ export const JR_cc_e8 = {
 export const CALL_NW = {
     m: 6,
     t: 24,
-    action: function ({ _r, operand1, operand2 }): void {
+    action: ({ _r, operand1, operand2 }): void => {
         const address: Address = new Address(operand1, operand2);
         
         _r.sp = _r.sp.ADD(-2);
-        MMU.ww(_r.sp, _r.pc.ADD(this.bytes));
+        MMU.ww(_r.sp, _r.pc.ADD(1));
         
-        this.pc = address;
-        this.bytes = 0;
+        _r.pc = address;
     },
     bytes: 3
 } as InstructionMetaData;
@@ -74,7 +73,6 @@ export const JR_EB = {
     t: 12,
     action: function ({ _r, operand1 }): void {
         _r.pc = _r.pc.ADD(this.bytes).ADD(operand1.getVal());
-        this.bytes = 0;
     },
     bytes: 2
 } as InstructionMetaData;

--- a/src/instructions/JumpsAndSubroutines.ts
+++ b/src/instructions/JumpsAndSubroutines.ts
@@ -2,6 +2,10 @@ import Address from '../models/data_types/Address.js';
 import MMU from '../MMU.js';
 import { InstructionMetaData } from './InstructionMetaData.js';
 
+function getSignedVal(val) {
+	return val > 0x7F ? val - 0x100 : val; 
+}
+
 // Return from interrupt (called by handler)
 export const RETI = {
     m: 3,
@@ -35,9 +39,9 @@ export const JR_cc_e8 = {
     t: 8,
     action: function ({ opcode1, operand1,  _r }): void {
         const conditionMet = this.map[opcode1.getVal()](_r.f.getVal());
-
+		const signedVal =  getSignedVal(operand1.getVal());
         if (conditionMet) {
-            _r.pc = _r.pc.ADD(operand1.getVal());
+            _r.pc = _r.pc.ADD(signedVal);
         }
 
         if (conditionMet) {

--- a/src/instructions/StackOperations.ts
+++ b/src/instructions/StackOperations.ts
@@ -16,9 +16,9 @@ export const PUSH_RW = {
         const [upper, lower] = this.map[opcode1.getVal() >> 4];
 
         _r.sp = _r.sp.ADD(-1);             // Drop through the stack
-        MMU.wb(_r.sp, upper);               // Write B
+        MMU.wb(_r.sp, _r[upper]);               // Write B
         _r.sp = _r.sp.ADD(-1);            // Drop through the stack
-        MMU.wb(_r.sp, lower);               // Write C
+        MMU.wb(_r.sp, _r[lower]);               // Write C
     },
     map: POP_PUSH_MAP,
     bytes: 1 
@@ -28,8 +28,8 @@ export const PUSH_RW = {
 export const POP_RW = {
     m: 3,
     t: 12,
-    action: ({ _r, opcode1 }) => {
-        const [upper, lower] = this.map[opcode1.getVal()];
+    action: function ({ _r, opcode1 }) {
+        const [upper, lower] = this.map[opcode1.getVal() >> 4];
         _r[lower] = MMU.rb(_r.sp);         // Read L
         _r.sp = _r.sp.ADD(1);              // Move back up the stack
         _r[upper] = MMU.rb(_r.sp);         // Read H


### PR DESCRIPTION
There were a couple of fixes added to this PR that includes fixing the infinite call loop. These changes include:

- Fixing the conditional jump using an 8 bit offset. I didn't realize that the offset was a signed integer. I did this by creating a helper function that will take an unsigned 8 bit integer and convert it to a signed integer. I then add this to the PC instead of the unsigned integer.

- The call to address function was originally just jumping to the new address, and the PC offset was being added to the address that was put on the call stack. It turns out that the offset should be added to the instruction that is being jumped to, and the instruction that is put on the stack is actually just the next instruction after the current one being executed.

- fixing some minor typo and context issue.

Closes #67 