### PR TITLE
Fixing Issue Where NAN was getting put into the A Register And Other Minor Things

### DIFF
--- a/src/GPU.ts
+++ b/src/GPU.ts
@@ -123,8 +123,8 @@ class GPU extends Logger implements LoggerInterface {
 
             // Update tile set
             this._tileset[tile][y][x] = 
-                ((this._vram.getValue(baseAddr).AND(sx)) ? 1 : 0) +
-                ((this._vram.getValue(baseAddr.ADD(1)).AND(sx)) ? 2 : 0);
+                ((this._vram.getValue(addr).AND(sx)) ? 1 : 0) +
+                ((this._vram.getValue(addr.ADD(1)).AND(sx)) ? 2 : 0);
         }
     }
 

--- a/src/MMU.ts
+++ b/src/MMU.ts
@@ -239,7 +239,7 @@ class MMU extends Logger implements LoggerInterface {
                         // Zero-page
                     case 0xF00:
                         if (addrVal >= 0xFF80) {
-                            this._zram.setValue(addr.AND(0x75), val);
+                            this._zram.setValue(addr, val);
                         } else {
                             // I/O 
                             switch(addrVal & 0x00F0) {

--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -19,7 +19,8 @@ function createClock(): { m: number, t: number }  {
 
 function setFlagBit(val: 0 | 1, pos: number, reg: Byte): Byte {
     const valStr = val.toString();
-    const regStr = reg.getVal().toString(2);
+    let regStr = reg.getVal().toString(2);
+	regStr = Array(5 - regStr.length).join("0") + regStr;
     const newRegVal = regStr.substring(0,pos) + valStr + regStr.substring(pos+1);
     
     return new Byte(Number('0b' + newRegVal));
@@ -106,9 +107,9 @@ class Z80 extends Logger implements LoggerInterface {
         0x06: Instructions.LD_RB_NB,
         0x0E: Instructions.LD_RB_NB,
         0x16: Instructions.LD_RB_NB,
+        0x1E: Instructions.LD_RB_NB,
         0x26: Instructions.LD_RB_NB,
         0x2E: Instructions.LD_RB_NB,
-        0x36: Instructions.LD_RB_NB,
         0x3E: Instructions.LD_RB_NB,
         0x70: Instructions.LD_HL_RB,
         0x71: Instructions.LD_HL_RB,

--- a/src/instructions/16BitArithmetic.ts
+++ b/src/instructions/16BitArithmetic.ts
@@ -4,7 +4,7 @@ import Address from "../models/data_types/Address.js";
 export const INC_NW = {
     m: 2,
     t: 8,
-    action: ({ _r, opcode1 }) => {
+    action: function({ _r, opcode1 }): void  {
         const [upper, lower] = this.map[opcode1.getVal() >> 4];
         const address: Address = new Address(_r[upper], _r[lower]);
         const newAddress: Address = address.ADD(1);

--- a/src/instructions/8BitArithmetic.ts
+++ b/src/instructions/8BitArithmetic.ts
@@ -96,6 +96,7 @@ export const DEC_RB = {
         const result = _r[reg].ADD(-1);
 
         _r.setN(1);
+		_r[reg] = result;
 
         if (!result.AND(255).getVal()) {
             _r.setZ(1);

--- a/src/instructions/BitOperations.ts
+++ b/src/instructions/BitOperations.ts
@@ -80,7 +80,7 @@ export const RLA = {
 		const newCarry: string = byte.shift();
 		
 		byte.push(carry);
-		const result = new Byte(Number(byte.join('')));
+		const result = new Byte(parseInt(byte.join(''), 2));
 		
 		_r.setH(0);
 		_r.setN(0);

--- a/src/instructions/BitOperations.ts
+++ b/src/instructions/BitOperations.ts
@@ -55,7 +55,7 @@ export const RL_r8 = {
         const newCarry: string = byte.shift();
         
         byte.push(carry);
-        const result = new Byte(Number(byte.join('')));
+        const result = new Byte(parseInt(byte.join(''), 2));
 
 		_r.setH(0);
 		_r.setN(0);

--- a/src/instructions/JumpsAndSubroutines.ts
+++ b/src/instructions/JumpsAndSubroutines.ts
@@ -61,13 +61,14 @@ export const JR_cc_e8 = {
 export const CALL_NW = {
     m: 6,
     t: 24,
-    action: ({ _r, operand1, operand2 }): void => {
+    action: function({ _r, operand1, operand2 }): void {
         const address: Address = new Address(operand1, operand2);
         
         _r.sp = _r.sp.ADD(-2);
-        MMU.ww(_r.sp, _r.pc.ADD(1));
+        MMU.ww(_r.sp, _r.pc.ADD(this.bytes));
         
         _r.pc = address;
+		this.bytes = 0;
     },
     bytes: 3
 } as InstructionMetaData;

--- a/src/instructions/JumpsAndSubroutines.ts
+++ b/src/instructions/JumpsAndSubroutines.ts
@@ -76,7 +76,7 @@ export const CALL_NW = {
 export const JR_EB = {
     m:3,
     t: 12,
-    action: function ({ _r, operand1 }): void {
+    action: function({ _r, operand1 }): void {
         _r.pc = _r.pc.ADD(this.bytes).ADD(operand1.getVal());
     },
     bytes: 2
@@ -85,9 +85,10 @@ export const JR_EB = {
 export const RET = {
     m: 4,
     t: 16,
-    action: ({ _r }): void => {
+    action: function({ _r }): void {
         _r.pc = new Address(MMU.rw(_r.sp));
         _r.sp = _r.sp.ADD(2);
+		this.bytes = 0;
     },
     bytes: 1
 } as InstructionMetaData;

--- a/src/instructions/Load.ts
+++ b/src/instructions/Load.ts
@@ -125,7 +125,7 @@ export function setLoadRegToRegVal(setFunc): Object {
                 lower.forEach((lowerVal, lowerIndex) => {
                     if(lowerVal) {
                         const lowerHalf = upperIndex ? lowerIndex + 8 : lowerIndex;
-                        map[Number(upperStr) << 4 + lowerHalf] = setFunc(upperVal, lowerVal); 
+                        map[(Number(upperStr) << 4) + lowerHalf] = setFunc(upperVal, lowerVal); 
                     }
                 });
             }

--- a/src/instructions/Load.ts
+++ b/src/instructions/Load.ts
@@ -59,9 +59,9 @@ export const LD_RB_NB = {
         0x06: 'b',
         0x0E: 'd',
         0x16: 'h',
+        0x1E: 'l',
         0x26: 'c',
         0x2E: 'e',
-        0x36: 'l',
         0x3E: 'a'
     },
     bytes: 2


### PR DESCRIPTION
This issue was originally created to fix a bug that was appearing in the registers. At first abnormally large numbers were getting added in to the A register and as instructions continued to be executed, the A register would eventually just hold NAN. Once the issue was fixed, there were a number of other issues that cropped up. I fixed them until i ran into an Issue which I was missing an instruction, which I felt was large enough to merit its own bug. The fixes includes:

- fixing GPU so update tile uses actual address instead of base address (due to using my own address schema and not Imran's

- Reverting changes to number of bytes jumped to the next instruction when executing CALL instruction

- The flag setting logic was wrong and had to be fixed to put flags in the correct place

- In a couple of instructions, I was converting from string representation of a binary number back to an integer using the Number constructor. This was converting the binary representation to a literal integer rather than converting to the integer representation of said number.

- fixed some context issues

- fixed the function that was adding a bunch of load instruction to the instruction map. it was calculating the wrong keys in the map so instructions weren't in there that were supposed to be

- the DEC instruction wasn't actually putting the decremented value in the register it was supposed to

closes #69 