### PR TITLE
Adding flag reset scheme

### DIFF
--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -10,6 +10,8 @@ import { RL_r8 } from './instructions/index.js';
 import Logger from './logging/implementations/Logger.js';
 import LoggerInterface from './logging/interfaces/Logger.js';
 
+const flags = ['h', 'z', 'n', 'c'];
+
 function createClock(): { m: number, t: number }  {
 	return {
     	m: 0, 
@@ -193,6 +195,19 @@ class Z80 extends Logger implements LoggerInterface {
 		} else {
 			metaData = { ...this._map[opcode.getVal()] };
 		}
+
+		flags.forEach((flag: string) => {
+			const flagVal = metaData[flag];
+			if (flagVal) {
+				const flagFunc = this._r['set' + flag.toUpperCase()];
+				if (flagVal === '?') {
+					flagFunc(0);	
+				} else {
+					flagFunc(flagVal);
+				}
+			}
+		});
+
 		this.executeInstructionAction(metaData, opcode);
 
         this._r.pc = this._r.pc.ADD(metaData.bytes).AND(65535);

--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -199,11 +199,10 @@ class Z80 extends Logger implements LoggerInterface {
 		flags.forEach((flag: string) => {
 			const flagVal = metaData[flag];
 			if (flagVal) {
-				const flagFunc = this._r['set' + flag.toUpperCase()];
 				if (flagVal === '?') {
-					flagFunc(0);	
+					this._r['set' + flag.toUpperCase()](0);	
 				} else {
-					flagFunc(flagVal);
+					this._r['set' + flag.toUpperCase()](flagVal);
 				}
 			}
 		});

--- a/src/instructions/8BitArithmetic.ts
+++ b/src/instructions/8BitArithmetic.ts
@@ -76,8 +76,6 @@ export const CP_A_NB = {
     action: ({ _r, operand1 }) => {
         const result: Byte = _r.a.ADD(-operand1.getVal());
         
-        _r.setN(1);
-
         if (!result.AND(255).getVal()) {
             _r.setZ(1);
         }
@@ -88,6 +86,10 @@ export const CP_A_NB = {
             _r.setC(1);
         }
     },
+	z: '?',
+	n: 1,
+	h: '?',
+	c: '?',
     bytes: 2
 } as InstructionMetaData;
 
@@ -99,7 +101,6 @@ export const DEC_RB = {
         const result = _r[reg].ADD(-1);
 
 		_r[reg] = result;
-        _r.setN(1);
 
         if (!result.AND(255).getVal()) {
             _r.setZ(1);
@@ -117,6 +118,9 @@ export const DEC_RB = {
         0x2D: 'l',
         0x3D: 'a'
     },
+	z: '?',
+	n: 1,
+	h: '?',
     bytes: 1
 } as InstructionMetaData;
 
@@ -128,7 +132,6 @@ export const SUB_A_RB = {
         const result = _r.a.ADD(-_r[reg].getVal());
 
 		_r.a = result;
-        _r.setN(1);
 
         if (!result.AND(255).getVal()) {
             _r.setZ(1);
@@ -141,7 +144,11 @@ export const SUB_A_RB = {
         }
     },
     map: ['b', 'c', 'd', 'e', 'h', 'l', null, 'a'],
-    bytes: 1
+	z: '?',
+	n: 1,
+	h: '?',
+	c: '?',
+	bytes: 1
 } as InstructionMetaData;
 
 export const CP_A_HL = {
@@ -152,8 +159,6 @@ export const CP_A_HL = {
         const cmprVal: number = MMU.rb(addr).getVal();
         const result: Byte = _r.a.ADD(-cmprVal);
         
-        _r.setN(1);
-
         if (!result.AND(255).getVal()) {
             _r.setZ(1);
         }
@@ -164,6 +169,10 @@ export const CP_A_HL = {
             _r.setC(1);
         }
     },
+	z: '?',
+	n: 1,
+	h: '?',
+	c: '?',
     bytes: 1
 } as InstructionMetaData;
 
@@ -174,8 +183,6 @@ export const ADD_A_HL = {
         const addr: Address = new Address(_r.h, _r.l);
         const addend: number = MMU.rb(addr).getVal();
         const result: Byte = _r.a.ADD(addend);
-
-        _r.setN(0);
 
         if (!result.AND(255).getVal()) {
             _r.setZ(1);
@@ -189,6 +196,10 @@ export const ADD_A_HL = {
 
         _r.a = result.AND(0x255);
     },
+	z: '?',
+	n: 0,
+	h: '?',
+	c: '?',
     bytes: 1
 } as InstructionMetaData;
 
@@ -203,10 +214,11 @@ export const XOR_A_RB = {
         if (!result.AND(255).getVal()) {
             _r.setZ(1);
         }
-        _r.setN(0);
-		_r.setH(0)
-		_r.setC(0);
 	},
 	map: ['b', 'c', 'd', 'e', 'h', 'l', null, 'a'],
+	z: '?',
+	n: 0,
+	h: 0,
+	c: 0,
 	bytes: 1
 };

--- a/src/instructions/8BitArithmetic.ts
+++ b/src/instructions/8BitArithmetic.ts
@@ -64,6 +64,9 @@ export const INC_RB = {
         0x2C: 'l',
         0x3C: 'a',
     },
+	z: "?",
+	n: 0,
+	h: "?",
     bytes: 1
 } as InstructionMetaData;
 

--- a/src/instructions/BitOperations.ts
+++ b/src/instructions/BitOperations.ts
@@ -57,9 +57,6 @@ export const RL_r8 = {
         byte.push(carry);
         const result = new Byte(parseInt(byte.join(''), 2));
 
-		_r.setH(0);
-		_r.setN(0);
-
         if (!result.AND(255).getVal()) {
         	_r.setZ(1);
 		}
@@ -68,7 +65,11 @@ export const RL_r8 = {
 		_r[reg] = result;
     },
     map: ['b', 'c', 'd', 'e', 'h', 'l', null, 'a'],
-    bytes: 2
+    z: '?',
+	n: 0,
+	h: 0,
+	c: '?',
+	bytes: 2
 } as InstructionMetaData;
 
 export const RLA = {
@@ -82,13 +83,14 @@ export const RLA = {
 		byte.push(carry);
 		const result = new Byte(parseInt(byte.join(''), 2));
 		
-		_r.setH(0);
-		_r.setN(0);
-		_r.setZ(0);
 		_r.setC(newCarry === '0' ? 0 : 1);
 
 		_r.a = result;
 	},
+	z: 0,
+	n: 0,
+	h: 0,
+	c: '?',
 	bytes: 1
 };
 

--- a/src/instructions/InstructionMetaData.ts
+++ b/src/instructions/InstructionMetaData.ts
@@ -14,10 +14,10 @@ export interface InstructionMetaData {
     m: number;
     t: number;
     action: { (data: ActionData): void };
-    z?: 0 | 1;
-    n?: 0 | 1;
-    h?: 0 | 1;
-    c?: 0 | 1;
+    z?: 0 | 1 | '?';
+    n?: 0 | 1 | '?';
+    h?: 0 | 1 | '?';
+    c?: 0 | 1 | '?';
     ime?: 0 | 1;
     bytes: number;
     map: object | Array<number | string> | {(opcode: Opcode): number};


### PR DESCRIPTION
Figured out that flags are reset by certain instructions when they are run after talking to Dave. There is a [site](https://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html) that shows what functions change what flags. I have a loop in the instruction execution that will go through each flag and see if it has a particular state on the metadata. If it does, set it to that state (? means set it to 0 because the instruction logic may or may not change it). The rest is just adding the flag data to the instruction metadata.

closes #77 