### PR TITLE
Fixing screen frame

### DIFF
--- a/src/GPU.ts
+++ b/src/GPU.ts
@@ -30,20 +30,21 @@ class GPU extends Logger implements LoggerInterface {
 
 	properties = [
 		'_mode',
-		'_bgmap',
-		'_bgtile',
-		'_switchbg',
-		'_switchobj',
-		'_switchlcd'
+//		'_bgmap',
+//		'_bgtile',
+//		'_switchbg',
+//		'_switchobj',
+//		'_switchlcd',
+	    '_line'
 	];
 
 	functions = [
-		'reset',
-		'updateTile',
+	//	'reset',
+	//	'updateTile',
 		'rb',
 		'wb',
-		'step',
-		'renderScan'
+	//	'step',
+	//	'renderScan'
 	];
 
 

--- a/src/Z80.ts
+++ b/src/Z80.ts
@@ -210,8 +210,8 @@ class Z80 extends Logger implements LoggerInterface {
 		this.executeInstructionAction(metaData, opcode);
 
         this._r.pc = this._r.pc.ADD(metaData.bytes).AND(65535);
-        this._clock.m += metaData.m;
-        this._clock.t += metaData.t;
+        this._r.m += metaData.m;
+        this._r.t += metaData.t;
     }
 
 	private executeInstructionAction(metaData: InstructionMetaData, opcode: Opcode): void {

--- a/src/jsGB.ts
+++ b/src/jsGB.ts
@@ -27,12 +27,14 @@ class GameBoy {
     frame() {
 		const fclk = Z80._clock.t + 70224;
         do {
-            Z80.executeCurrentInstruction(); 
+            // Reset Instruction Timer Count
+			Z80._r.m = 0;
+            Z80._r.t = 0;
+            
+			Z80.executeCurrentInstruction(); 
             // Update the Timer
             TIMER.inc();
 
-            Z80._r.m = 0;
-            Z80._r.t = 0;
 
             GPU.step();
 

--- a/src/logging/displays/Console.ts
+++ b/src/logging/displays/Console.ts
@@ -44,12 +44,21 @@ export default class Console implements Display {
 			logTypes: [
 				LogTypes.functions,
 			]
+		},
+		{
+			classType: 'GPU',
+			logTypes: [
+				LogTypes.functions,
+				LogTypes.properties
+			]
 		}
 	];	
 
 	logProperties(classId: number, className: string, name: string, value: any) {
 		if (className === 'Z80' && name === '_r') {
 			registers = value;
+		} else {
+			log(className, `Prop: ${name}: ${value}`);
 		}
 	}
 


### PR DESCRIPTION
This is a fix to prevent the infinite loop that occurs in the set of instructions that is checking for the screen frame to finish. This was due to the Execute instruction function by passing the register count and putting it directly in the instruction count. The GPU relies on the register count being updated in order to push its count forward in its stepping function. Due to this, the address that represents the line was not being updated, and there for the conditional jump was always proving true.

Closes #81 