### PR TITLE
Fixing Major GPU Bug and some Minor Timing issues and Semantic Bugs

### DIFF
--- a/src/GPU.ts
+++ b/src/GPU.ts
@@ -21,7 +21,6 @@ class GPU extends Logger implements LoggerInterface {
     _switchbg = 0;
     _switchobj = 0;
     _switchlcd = 0;
-	_modeClockAdder = 0;
     _pal = {
         bg: [],
         obj0: [],
@@ -244,7 +243,6 @@ class GPU extends Logger implements LoggerInterface {
             case 2: {
                 if (this._modeClock >= 80) {
                     // Set Next step to VRAM read mode
-					this._modeClockAdder += this._modeClock;
                     this._modeClock = this._modeClock % 80;
                     this._mode = 3;
                 }
@@ -256,7 +254,6 @@ class GPU extends Logger implements LoggerInterface {
             case 3: {
                 if(this._modeClock >= 172) {
                     // Set Next step to hblank mode
-					this._modeClockAdder += this._modeClock;
                     this._modeClock = this._modeClock % 172;
                     this._mode = 0;
 
@@ -270,7 +267,6 @@ class GPU extends Logger implements LoggerInterface {
             // After the last hblank, push screen data to canvas
             case 0: {
                 if(this._modeClock >= 204) {
-					this._modeClockAdder += this._modeClock;
                     this._modeClock = this._modeClock % 204;
                     this._line = this._line.ADD(1);
 
@@ -281,14 +277,12 @@ class GPU extends Logger implements LoggerInterface {
                     } else {
                         this._mode = 2;
                     }
-				console.log(`Scanline End: ${this._line.getVal()} ->  Global Left Over: ${(Z80._clock.t + Z80._r.t) % 456} = ModeClock: ${this._modeClock}, Global Clock: ${Z80._clock.t + Z80._r.t}, Calculated Scanline Clock: ${this._line.getVal() * 456} `);
                 }
                 break;
             }
 
             case 1: {
                 if(this._modeClock >= 456) {
-					this._modeClockAdder += this._modeClock;
                     this._modeClock = this._modeClock % 456;
                     this._line = this._line.ADD(1);
 
@@ -297,7 +291,6 @@ class GPU extends Logger implements LoggerInterface {
                         this._mode = 2;
                         this._line = new Byte(0);
                     }
-					console.log(`V-Blank Line End: ${this._line.getVal()} ->  Global Left Over: ${(Z80._clock.t + Z80._r.t) % 456} = ModeClock: ${this._modeClock}, Global Clock: ${Z80._clock.t + Z80._r.t}, Calculated Scanline Clock: ${this._line.getVal() * 456} `);
                 }
                 break;
             }

--- a/src/instructions/BitOperations.ts
+++ b/src/instructions/BitOperations.ts
@@ -5,7 +5,10 @@ import { InstructionMetaData } from './InstructionMetaData.js';
 import Byte from '../models/data_sizes/Byte.js';
 
 let registerMap = ['b', 'c', 'd', 'e', 'h', 'l', 'hl', 'a'];
-registerMap = registerMap.concat(registerMap);
+// Double the register map array because the 16bit instruction matrix uses
+// the entire upper half of the opcode (0x0 - 0xF) to detirmine which register
+// the instructions are going to affect, repeating when it gets to 0x8
+registerMap = registerMap.concat(registerMap); 
 
 export const BITu3r8 = {
     m: 2,
@@ -14,7 +17,7 @@ export const BITu3r8 = {
         const bitNum = this.map(opcode2);
         const reg = registerMap[opcode2.getVal() & 0xF];
 
-        if ((_r[reg] & bitNum) === 0) {
+        if ((_r[reg].getVal() & bitNum) === 0) {
             _r.setZ(1);
         }
     },
@@ -33,14 +36,15 @@ export const BITu3r8 = {
             return 0x10;
         } else if (opVal >= 0x68 && opVal <= 0x6f) {
             return 0x20;
-        } else if (opVal >= 0x40 && opVal <= 0x47) {
+        } else if (opVal >= 0x70 && opVal <= 0x77) {
             return 0x40;
-        } else if (opVal >= 0x40 && opVal <= 0x47) {
+        } else if (opVal >= 0x78 && opVal <= 0x7f) {
             return 0x80;
         }
     },
     n: 0,
     h: 1,
+	z: '?',
     bytes: 2
 } as InstructionMetaData;
 

--- a/src/instructions/JumpsAndSubroutines.ts
+++ b/src/instructions/JumpsAndSubroutines.ts
@@ -40,13 +40,11 @@ export const JR_cc_e8 = {
     action: function ({ opcode1, operand1,  _r }): void {
         const conditionMet = this.map[opcode1.getVal()](_r.f.getVal());
 		const signedVal =  getSignedVal(operand1.getVal());
-        if (conditionMet) {
+        
+		if (conditionMet) {
             _r.pc = _r.pc.ADD(signedVal);
-        }
-
-        if (conditionMet) {
             this.m = 3;
-            this.m = 12;
+            this.t = 12;
         }
     },
     map: {

--- a/src/instructions/StackOperations.ts
+++ b/src/instructions/StackOperations.ts
@@ -40,8 +40,8 @@ export const POP_RW = {
 } as InstructionMetaData;
 
 export const LDSPnn = {
-    m: 4,
-    t: 16,
+    m: 3,
+    t: 12,
     action: ({ _r, operand1, operand2 }) => {
         _r.sp = new Address(operand1, operand2);       // Load up next word in memory after opcode and store in stack pointer     
     },

--- a/src/jsGB.ts
+++ b/src/jsGB.ts
@@ -26,6 +26,8 @@ class GameBoy {
 
     frame() {
 		const fclk = Z80._clock.t + 70224;
+		let opcodesRun = 0;
+
         do {
             // Reset Instruction Timer Count
 			Z80._r.m = 0;
@@ -55,6 +57,7 @@ class GameBoy {
 
             // Update timer again, in case a RST occured
             TIMER.inc();
+			opcodesRun += 1;
         } while (Z80._clock.t < fclk);
     }
 

--- a/src/jsGB.ts
+++ b/src/jsGB.ts
@@ -26,7 +26,6 @@ class GameBoy {
 
     frame() {
 		const fclk = Z80._clock.t + 70224;
-		let opcodesRun = 0;
 
         do {
             // Reset Instruction Timer Count
@@ -57,7 +56,6 @@ class GameBoy {
 
             // Update timer again, in case a RST occured
             TIMER.inc();
-			opcodesRun += 1;
         } while (Z80._clock.t < fclk);
     }
 

--- a/src/logging/displays/Console.ts
+++ b/src/logging/displays/Console.ts
@@ -35,7 +35,7 @@ export default class Console implements Display {
 		{
 			classType: 'Z80',
 			logTypes: [
-//				LogTypes.properties,
+				LogTypes.properties,
 //				LogTypes.functions
 			]
 		},


### PR DESCRIPTION
There were a few issues causing this problem, but the main one was that the modeClock was resetting to 0 even if there was left over cycles after the timer was up. 

- Removing logging for temp purposes
- fixing modeClock reset so it still has overflow when it resets
- Adding in some forgotten changes from the BIT instruction and some semantic bugs
- Adding a missing flag definition in the BIT instruction
- Fixing some timings in a few instructions

Closes #86 